### PR TITLE
Add datetimeoffset

### DIFF
--- a/LinqToQueryString.UnitTests/Filtering.cs
+++ b/LinqToQueryString.UnitTests/Filtering.cs
@@ -1,4 +1,4 @@
-﻿namespace LinqToQueryString.UnitTests
+namespace LinqToQueryString.UnitTests
 {
     using System;
     using System.Collections.Generic;
@@ -1202,6 +1202,118 @@
 
     #endregion
 
+    #region Filter on date with offset tests
+
+    public class When_using_eq_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=Date eq datetimeoffset'2002-01-01T00:00.000Z'");
+
+        private It should_return_three_records = () => result.Count().ShouldEqual(3);
+
+        private It should_only_return_records_where_date_is_2002_01_01 = () => result.ShouldEachConformTo(o => o.Date == new DateTime(2002, 01, 01));
+    }
+
+    public class When_using_not_eq_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=not Date eq datetimeoffset'2002-01-01T00:00.000Z'");
+
+        private It should_return_eight_records = () => result.Count().ShouldEqual(8);
+
+        private It should_only_return_records_where_age_is_not_2002_01_01 = () => result.ShouldEachConformTo(o => o.Date != new DateTime(2002, 01, 01));
+    }
+
+    public class When_using_ne_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=Date ne datetimeoffset'2002-01-01T00:00.000Z'");
+
+        private It should_return_eight_records = () => result.Count().ShouldEqual(8);
+
+        private It should_only_return_records_where_age_is_not_2002_01_01 = () => result.ShouldEachConformTo(o => o.Date != new DateTime(2002, 01, 01));
+    }
+
+    public class When_using_not_ne_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=not Date ne datetimeoffset'2002-01-01T00:00.000Z'");
+
+        private It should_return_three_records = () => result.Count().ShouldEqual(3);
+
+        private It should_only_return_records_where_age_is_2002_01_01 = () => result.ShouldEachConformTo(o => o.Date == new DateTime(2002, 01, 01));
+    }
+
+    public class When_using_gt_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=Date gt datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(3);
+
+        private It should_only_return_records_where_age_is_greater_than_3 = () => result.ShouldEachConformTo(o => o.Date > new DateTime(2003, 01, 01));
+    }
+
+    public class When_using_not_gt_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=not Date gt datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(8);
+
+        private It should_only_return_records_where_age_is_not_greater_than_3 = () => result.ShouldEachConformTo(o => !(o.Date > new DateTime(2003, 01, 01)));
+    }
+
+    public class When_using_ge_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=Date ge datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(6);
+
+        private It should_only_return_records_where_age_is_greater_than_or_equal_to_3 = () => result.ShouldEachConformTo(o => o.Date >= new DateTime(2003, 01, 01));
+    }
+
+    public class When_using_not_ge_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=not Date ge datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(5);
+
+        private It should_only_return_records_where_age_is_not_greater_than_or_equal_to_3 = () => result.ShouldEachConformTo(o => !(o.Date >= new DateTime(2003, 01, 01)));
+    }
+
+    public class When_using_lt_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=Date lt datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(5);
+
+        private It should_only_return_records_where_age_is_less_than_3 = () => result.ShouldEachConformTo(o => o.Date < new DateTime(2003, 01, 01));
+    }
+
+    public class When_using_not_lt_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=not Date lt datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(6);
+
+        private It should_only_return_records_where_age_is_not_less_than_3 = () => result.ShouldEachConformTo(o => !(o.Date < new DateTime(2003, 01, 01)));
+    }
+
+    public class When_using_le_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=Date le datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(8);
+
+        private It should_only_return_records_where_age_is_less_than_or_equal_to_3 = () => result.ShouldEachConformTo(o => o.Date <= new DateTime(2003, 01, 01));
+    }
+
+    public class When_using_not_le_filter_on_a_single_date_with_offset : Filtering
+    {
+        private Because of = () => result = concreteCollection.AsQueryable().LinqToQuerystring("?$filter=not Date le datetimeoffset'2003-01-01T00:00.000Z'");
+
+        private It should_return_two_records = () => result.Count().ShouldEqual(3);
+
+        private It should_only_return_records_where_age_is_not_less_than_or_equal_to_3 = () => result.ShouldEachConformTo(o => !(o.Date <= new DateTime(2003, 01, 01)));
+    }
+
+    #endregion
+
     #region Filter on bool tests
 
     public class When_using_eq_filter_on_a_single_bool : Filtering
@@ -1471,6 +1583,15 @@
     public class When_using_eq_filter_on_a_single_nullable_date : Filtering
     {
         private Because of = () => nullableResult = nullableCollection.AsQueryable().LinqToQuerystring("?$filter=Date eq datetime'2002-01-01T00:00'");
+
+        private It should_return_the_correct_number_of_records = () => nullableResult.Count().ShouldEqual(1);
+
+        private It should_only_return_matching_records = () => nullableResult.ShouldEachConformTo(o => o.Date == new DateTime(2002, 01, 01));
+    }
+
+    public class When_using_eq_filter_on_a_single_nullable_date_with_offset : Filtering
+    {
+        private Because of = () => nullableResult = nullableCollection.AsQueryable().LinqToQuerystring("?$filter=Date eq datetime'2002-01-01T00:00.000Z'");
 
         private It should_return_the_correct_number_of_records = () => nullableResult.Count().ShouldEqual(1);
 

--- a/LinqToQuerystring/LinqToQuerystring.csproj
+++ b/LinqToQuerystring/LinqToQuerystring.csproj
@@ -63,6 +63,7 @@
     <Compile Include="TreeNodes\Base\TwoChildNode.cs" />
     <Compile Include="TreeNodes\DataTypes\BoolNode.cs" />
     <Compile Include="TreeNodes\DataTypes\ByteNode.cs" />
+    <Compile Include="TreeNodes\DataTypes\DateTimeOffsetNode.cs" />
     <Compile Include="TreeNodes\DataTypes\DecimalNode.cs" />
     <Compile Include="TreeNodes\Functions\DayNode.cs" />
     <Compile Include="TreeNodes\Functions\DaysNode.cs" />
@@ -124,7 +125,7 @@
   <PropertyGroup>
     <PreBuildEvent>$(ProjectDir)..\lib\ANTLR\Antlr3.exe $(ProjectDir)LinqToQuerystring.g -o $(ProjectDir)</PreBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/LinqToQuerystring/LinqToQuerystring.g
+++ b/LinqToQuerystring/LinqToQuerystring.g
@@ -35,18 +35,18 @@ public prog
 
 param	:	(orderby | top | skip | filter | select | inlinecount | expand | ignored);
 
-skip	
+skip
 	:	SKIP^ INT+;
 
-top	
+top
 	:	TOP^ INT+;
 
-filter	
+filter
 	:	FILTER^ filterexpression[false];
-	
+
 select
 	:	SELECT^ propertyname[false] (','! propertyname[false])*;
-			
+
 expand
 	:	EXPAND^ propertyname[false] (','! propertyname[false])*;
 
@@ -58,44 +58,44 @@ ignored	:	IGNORED IDENTIFIER -> IGNORED;
 
 filterexpression[bool subquery]
 	:	orexpression[subquery] (SPACE! OR^ SPACE! orexpression[subquery])*;
-	
+
 orexpression[bool subquery]
 	:	andexpression[subquery] (SPACE! AND^ SPACE! andexpression[subquery])*;
-	
+
 andexpression[bool subquery]
 	:	NOT^ SPACE ('(' filterexpression[subquery] ')' | booleanexpression[subquery])
 	|	('(' filterexpression[subquery] ')' | booleanexpression[subquery]);
-		
+
 booleanexpression[bool subquery]
 	:	atom1=atom[subquery] (
-			SPACE (op=EQUALS | op=NOTEQUALS | op=GREATERTHAN | op=GREATERTHANOREQUAL | op=LESSTHAN | op=LESSTHANOREQUAL) SPACE atom2=atom[subquery] 	
+			SPACE (op=EQUALS | op=NOTEQUALS | op=GREATERTHAN | op=GREATERTHANOREQUAL | op=LESSTHAN | op=LESSTHANOREQUAL) SPACE atom2=atom[subquery]
 			-> ^($op $atom1 $atom2)
 		|	-> ^(EQUALS["eq"] $atom1 BOOL["true"])
 		);
-		
+
 atom[bool subquery]
 	:	functioncall[subquery]
 	|	constant
 	|	accessor[subquery];
-	
+
 functioncall[bool subquery]
 	:	function^ '(' atom[subquery] (',' atom[subquery])* ')';
-	
+
 accessor[bool subquery]:
 		(propertyname[subquery] -> propertyname) (
-			'/' (func=ANY | func=ALL | func=COUNT | func=MAX | func=MIN | func=SUM | func=AVERAGE) 
+			'/' (func=ANY | func=ALL | func=COUNT | func=MAX | func=MIN | func=SUM | func=AVERAGE)
 			'(' (
 				(id=IDENTIFIER ':' SPACE filterexpression[true]) -> ^($func $accessor ALIAS[$id] filterexpression)
 				| -> ^($func $accessor) )
-			')' 
+			')'
 		)?;
-	
+
 function
 	:	STARTSWITH | ENDSWITH | SUBSTRINGOF | TOLOWER | TOUPPER | YEAR | YEARS | MONTH | DAY | DAYS | HOUR | HOURS | MINUTE | MINUTES | SECOND | SECONDS;
-		
+
 orderby
 	:	ORDERBY^ orderbylist;
-	
+
 orderbylist
 	:	orderpropertyname (','! orderpropertyname)*;
 
@@ -104,15 +104,15 @@ orderpropertyname
 			-> ^(ASC["asc"] propertyname)
 			| (SPACE (op=ASC | op=DESC)) -> ^($op propertyname)
 		);
-	
-constant:	(INT^ | BOOL^ | STRING^ | DATETIME^ | LONG^ | SINGLE^ | DECIMAL^ | DOUBLE^ | GUID^ | BYTE^ | NULL^);
+
+constant:	(INT^ | BOOL^ | STRING^ | DATETIME^ | DATETIMEOFFSET^ | LONG^ | SINGLE^ | DECIMAL^ | DOUBLE^ | GUID^ | BYTE^ | NULL^);
 
 propertyname[bool subquery]
 	:	(identifierpart[subquery] -> identifierpart) ('/' next=subpropertyname[false] -> ^($propertyname $next))?;
 
 subpropertyname[bool subquery]
 	:	propertyname[false];
-	
+
 identifierpart[bool subquery]
 	:	(id=IDENTIFIER -> {subquery}? ALIAS[$id]
 				-> IDENTIFIER[$id]
@@ -120,46 +120,46 @@ identifierpart[bool subquery]
 
 filteroperator
 	:	EQUALS | NOTEQUALS | GREATERTHAN | GREATERTHANOREQUAL | LESSTHAN | LESSTHANOREQUAL;
-	
+
 ASSIGN
 	: 	'=';
 
-EQUALS	
-	:	'eq';	
-	
-NOTEQUALS	
-	:	'ne';	
-	
-GREATERTHAN	
-	:	'gt';	
-	
-GREATERTHANOREQUAL
-	:	'ge';	
-	
-LESSTHAN	
-	:	'lt';	
-	
-LESSTHANOREQUAL
-	:	'le';	
+EQUALS
+	:	'eq';
 
-NOT		
+NOTEQUALS
+	:	'ne';
+
+GREATERTHAN
+	:	'gt';
+
+GREATERTHANOREQUAL
+	:	'ge';
+
+LESSTHAN
+	:	'lt';
+
+LESSTHANOREQUAL
+	:	'le';
+
+NOT
 	:	'not';
 
-OR	
+OR
 	:	'or';
 
-AND	
+AND
 	: 	'and';
 
-ASC	
+ASC
 	:	'asc';
-	
-DESC	
-	:	'desc';	
-	
+
+DESC
+	:	'desc';
+
 ALLPAGES
 	: 	'allpages';
-	
+
 NONE
 	:	'none';
 
@@ -174,67 +174,67 @@ FILTER
 
 ORDERBY
 	:	'$orderby=';
-	
+
 SELECT
 	:	'$select=';
-	
+
 INLINECOUNT
 	:	'$inlinecount=';
-	
+
 EXPAND	:	'$expand=';
-	
+
 IGNORED :	'$' IDENTIFIER '=';
-	
+
 STARTSWITH
 	:	'startswith';
-	
+
 ENDSWITH
 	:	'endswith';
-	
+
 SUBSTRINGOF
 	:	'substringof';
-	
+
 TOLOWER
 	:	'tolower';
 
 TOUPPER
 	:	'toupper';
-	
+
 YEAR
 	:	'year';
-	
+
 YEARS
 	:	'years';
-	
+
 MONTH
 	:	'month';
-	
+
 DAY
 	:	'day';
-	
+
 DAYS
 	:	'days';
-	
+
 HOUR
 	:	'hour';
-	
+
 HOURS
 	:	'hours';
-	
+
 MINUTE
 	:	'minute';
-	
+
 MINUTES
 	:	'minutes';
-	
+
 SECOND
 	:	'second';
-	
+
 SECONDS
 	:	'seconds';
 
 ANY	: 	'any';
-	
+
 ALL	:	'all';
 
 COUNT	:	'count';
@@ -246,24 +246,27 @@ MAX	:	'max';
 SUM	:	'sum';
 
 AVERAGE	:	'average';
-		
+
 INT	:	('-')? '0'..'9'+;
-	
+
 LONG	:	('-')? ('0'..'9')+ 'L';
-	
+
 DOUBLE	:	('-')? ('0'..'9')+ '.' ('0'..'9')+ 'd'?;
-	
+
 SINGLE	:	('-')? ('0'..'9')+ '.' ('0'..'9')+ 'f';
 
 DECIMAL	:	('-')? ('0'..'9')+ '.' ('0'..'9')+ 'm';
-	
+
 BOOL	:	('true' | 'false');
 
 NULL	:	'null';
 
 DATETIME
 	:	'datetime\'' '0'..'9'+ '-' '0'..'9'+ '-' + '0'..'9'+ 'T' '0'..'9'+ ':' '0'..'9'+ (':' '0'..'9'+ ('.' '0'..'9'+)*)* ('Z')? '\'';
-	
+
+DATETIMEOFFSET
+	:	'datetimeoffset\'' '0'..'9'+ '-' '0'..'9'+ '-' + '0'..'9'+ 'T' '0'..'9'+ ':' '0'..'9'+ (':' '0'..'9'+ ('.' '0'..'9'+)*)* ('Z')? '\'';
+
 GUID	:	'guid\'' HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR '\'';
 
 BYTE	:	'0x' HEX_PAIR;
@@ -271,17 +274,17 @@ BYTE	:	'0x' HEX_PAIR;
 SPACE	:	(' '|'\t')+;
 
 NEWLINE :	('\r'|'\n')+;
-	
+
 DYNAMICIDENTIFIER
-	:	'[' ('a'..'z'|'A'..'Z'|'0'..'9'|'_')+ ']';	
-	
+	:	'[' ('a'..'z'|'A'..'Z'|'0'..'9'|'_')+ ']';
+
 fragment
 HEX_PAIR
 	: HEX_DIGIT HEX_DIGIT;
-	
+
 IDENTIFIER
 	:	('a'..'z'|'A'..'Z') ('a'..'z'|'A'..'Z'|'0'..'9'|'_')*;
-	
+
 STRING 	: 	'\'' (ESC_SEQ| ~('\\'|'\''))* '\'';
 
 fragment

--- a/LinqToQuerystring/LinqToQuerystring.g
+++ b/LinqToQuerystring/LinqToQuerystring.g
@@ -265,7 +265,7 @@ DATETIME
 	:	'datetime\'' '0'..'9'+ '-' '0'..'9'+ '-' + '0'..'9'+ 'T' '0'..'9'+ ':' '0'..'9'+ (':' '0'..'9'+ ('.' '0'..'9'+)*)* ('Z')? '\'';
 
 DATETIMEOFFSET
-	:	'datetimeoffset\'' '0'..'9'+ '-' '0'..'9'+ '-' + '0'..'9'+ 'T' '0'..'9'+ ':' '0'..'9'+ (':' '0'..'9'+ ('.' '0'..'9'+)*)* ('Z')? '\'';
+	:	'datetimeoffset\'' '0'..'9'+ '-' '0'..'9'+ '-' + '0'..'9'+ 'T' '0'..'9'+ ':' '0'..'9'+ (':' '0'..'9'+ ('.' '0'..'9'+)?)? ((('+'|'-')'0'..'9'+ ':' '0'..'9'+)|'Z')? '\'';
 
 GUID	:	'guid\'' HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR '-' HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR HEX_PAIR '\'';
 

--- a/LinqToQuerystring/TreeNodes/DataTypes/DateTimeOffsetNode.cs
+++ b/LinqToQuerystring/TreeNodes/DataTypes/DateTimeOffsetNode.cs
@@ -1,0 +1,28 @@
+namespace LinqToQuerystring.TreeNodes.DataTypes
+{
+    using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    using Antlr.Runtime;
+
+    using LinqToQuerystring.TreeNodes.Base;
+
+    public class DateTimeOffsetNode : TreeNode
+    {
+        public DateTimeOffsetNode(Type inputType, IToken payload, TreeNodeFactory treeNodeFactory)
+            : base(inputType, payload, treeNodeFactory)
+        {
+        }
+
+        public override Expression BuildLinqExpression(IQueryable query, Expression expression, Expression item = null)
+        {
+            var dateText = this.Text
+                .Replace("datetimeoffset'", string.Empty)
+                .Replace("'", string.Empty);
+
+            return Expression.Constant(DateTime.Parse(dateText, null, DateTimeStyles.AssumeUniversal));
+        }
+    }
+}

--- a/LinqToQuerystring/TreeNodes/TreeNodeFactory.cs
+++ b/LinqToQuerystring/TreeNodes/TreeNodeFactory.cs
@@ -126,6 +126,8 @@
                     return new IntNode(inputType, token, this);
                 case LinqToQuerystringLexer.DATETIME:
                     return new DateTimeNode(inputType, token, this);
+                case LinqToQuerystringLexer.DATETIMEOFFSET:
+                    return new DateTimeOffsetNode(inputType, token, this);
                 case LinqToQuerystringLexer.DOUBLE:
                     return new DoubleNode(inputType, token, this);
                 case LinqToQuerystringLexer.SINGLE:


### PR DESCRIPTION
Adds datetimeoffset

Edm.DateTimeOffset
Represents date and time as an Offset in minutes from GMT, with values ranging from 12:00:00 midnight, January 1, 1753 A.D. through 11:59:59 P.M, December 9999 A.D datetimeoffset'<dateTimeOffsetLiteral>' dateTimeOffsetLiteral = Defined by the lexical representation for datetime (including timezone offset) at http://www.w3.org/TR/xmlschema-2  Example 1: 2002-10-10T17:00:00Z
